### PR TITLE
Add paywall support for protected routes

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -121,7 +121,7 @@ app.post('*/invoice', async (req, res, next) => {
 
     res.status(200).json(invoice)
   } catch (error) {
-    console.error(`${error.status} | ${error.message}`)
+    console.error('error getting invoice:', error)
     res.status(400).json({ message: error.message })
   }
 })
@@ -193,7 +193,7 @@ app.get('*/invoice', async (req, res, next) => {
         .json({ message: `unknown invoice status ${status}` })
     }
   } catch (error) {
-    console.error(`${error.status} | ${error.message}`)
+    console.error('error getting invoice:', error)
     res.status(400).json({ message: error.message })
   }
 })

--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,7 @@ var bodyParser = require('body-parser')
 const MacaroonsBuilder = require('macaroons.js').MacaroonsBuilder
 const lnService = require('ln-service')
 
+const { test } = require('./helpers')
 let protectedRoute = require('./_entrypoint')
 
 const router = express.Router()
@@ -56,6 +57,7 @@ See README for instructions: https://github.com/bucko13/now-paywall'
 }
 
 app.use('*', async (req, res, next) => {
+  test()
   try {
     testEnvVars()
     const { OPEN_NODE_KEY, LN_CERT, LN_MACAROON, LN_SOCKET } = process.env

--- a/server/app.js
+++ b/server/app.js
@@ -34,7 +34,7 @@ app.use(
     name: 'macaroon',
     maxAge: 86400000,
     secret: process.env.SESSION_SECRET || 'i_am_satoshi_08',
-    overwrite: true,
+    overwrite: false,
     signed: true,
   })
 )
@@ -45,12 +45,14 @@ app.use(
     name: 'dischargeMacaroon',
     maxAge: 86400000,
     secret: process.env.SESSION_SECRET || 'i_am_satoshi_08',
-    overwrite: true,
+    overwrite: false,
     signed: true,
   })
 )
 
 app.use('*', async (req, res, next) => {
+  console.log('req.session.macaroon:', req.session.macaroon)
+  console.log('req.session.dischargeMacaroon:', req.session.dischargeMacaroon)
   try {
     testEnvVars()
     const { OPEN_NODE_KEY, LN_CERT, LN_MACAROON, LN_SOCKET } = process.env
@@ -160,6 +162,7 @@ app.use('*/protected', async (req, res, next) => {
     'Checking if the request has been authorized or still requires payment...'
   )
   const rootMacaroon = req.session.macaroon
+  console.log('Do we have a rootMacaroon?', rootMacaroon)
   // if there is no macaroon at all
   if (!rootMacaroon) {
     try {

--- a/server/app.js
+++ b/server/app.js
@@ -401,7 +401,7 @@ async function createRootMacaroon(invoice, req) {
 }
 
 /*
- * Checkst the status of an invoice given an id
+ * Checks the status of an invoice given an id
  * @params {express.request} - request object from expressjs
  * @params {req.query.id} invoiceId - id of invoice to check status of
  * @params {req.lnd} [lnd] - ln-service authenticated grpc object
@@ -487,8 +487,6 @@ function validateMacaroons(root, discharge, exactCaveat) {
     // TODO: should probably generalize the exact caveat check or export as constant.
     // This would fail even if there is a space missing in the caveat creation
     if (exactCaveat.prefixMatch(caveat) && caveat !== exactCaveat.caveat) {
-      console.log('exactCaveat:', exactCaveat.caveat)
-      console.log('caveat:', caveat)
       throw new Error(`${exactCaveat.key} did not match with macaroon`)
     }
   }
@@ -548,7 +546,7 @@ function getFirstPartyCaveatFromMacaroon(serialized) {
 }
 
 /*
- * Utility function for get a location string to describe _where_ are
+ * Utility function to get a location string to describe _where_ the server is.
  * useful for setting identifiers in macaroons
  * @params {Express.request} req - expressjs request object
  * @params {Express.request.headers} [headers] - optional headers property added by zeit's now
@@ -562,7 +560,8 @@ function getLocation({ headers, hostname }) {
 }
 
 // returns a set of mostly constants that describes the first party caveat
-// this is set on a root macaroon
+// this is set on a root macaroon. Supports an empty invoiceId
+// since we can use this for matching the prefix on a populated macaroon caveat
 function getFirstPartyCaveat(invoiceId = '') {
   return {
     key: 'invoiceId',

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,0 +1,1 @@
+exports.test = () => console.log('hello world!')

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,1 +1,0 @@
-exports.test = () => console.log('hello world!')

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "bufferutil": "^4.0.1",
+    "cookie-session": "^1.3.3",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "ln-service": "bucko13/ln-service#path",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -501,6 +501,15 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
+cookie-session@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/cookie-session/-/cookie-session-1.3.3.tgz#54fa63881bf87c4961863f7c059670be7517fdae"
+  integrity sha512-GrMdrU1YTQWtmVTo0Rj3peeZRMc2xJrBslFYtZcYTo+hrSLmrcf69OrRkDi84xTfylgCy2wgpRHyY4le6lE5+A==
+  dependencies:
+    cookies "0.7.3"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -510,6 +519,14 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookies@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.3.tgz#7912ce21fbf2e8c2da70cf1c3f351aecf59dadfa"
+  integrity sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==
+  dependencies:
+    depd "~1.1.2"
+    keygrip "~1.0.3"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1041,6 +1058,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+keygrip@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
+  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
 
 lcid@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* modularizes a lot of the functionality from the invoices endpoints that are shared in the protected route

* protected routes handle both root and discharge macaroons

* w/ protected routes, root macaroon's first-party caveat uses the invoice id so that it can be easily identified

* started to make caveat's more abstract so they can have flexibility added to them later